### PR TITLE
Contacts API: Properties Dictionary Fixes, first Unit Tests

### DIFF
--- a/HubSpot.NET.Tests/Api/Contact/Dto/ContactHSModelTests.cs
+++ b/HubSpot.NET.Tests/Api/Contact/Dto/ContactHSModelTests.cs
@@ -51,16 +51,18 @@ namespace HubSpot.NET.Tests.Api.Contact.Dto
                 ZipCode = zip
             };
 
-            Assert.Equal(email, sut.Properties["email"].Value);
-            Assert.Equal(fName, sut.Properties["firstname"].Value);
-            Assert.Equal(lName, sut.Properties["lastname"].Value);
-            Assert.Equal(site, sut.Properties["website"].Value);
-            Assert.Equal(comp, sut.Properties["company"].Value);
-            Assert.Equal(phone, sut.Properties["phone"].Value);
-            Assert.Equal(addr, sut.Properties["address"].Value);
-            Assert.Equal(city, sut.Properties["city"].Value);
-            Assert.Equal(state, sut.Properties["state"].Value);
-            Assert.Equal(zip, sut.Properties["zip"].Value);
+            sut.LoadProperties();
+
+            Assert.True(!sut.Properties.ContainsKey("email") || email == sut.Properties["email"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("firstname") || fName == sut.Properties["firstname"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("lastname") || lName == sut.Properties["lastname"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("website") || site == sut.Properties["website"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("company") || comp == sut.Properties["company"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("phone") || phone == sut.Properties["phone"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("address") || addr == sut.Properties["address"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("city") || city == sut.Properties["city"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("state") || state == sut.Properties["state"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("zip") ||  zip == sut.Properties["zip"].Value as string);
         }
 
         [Theory]
@@ -99,26 +101,32 @@ namespace HubSpot.NET.Tests.Api.Contact.Dto
                 ZipCode = zip
             };
 
-            //Assert.Equal(sut.Properties["email"].Value, sut.Email);
-            //Assert.Equal(sut.Properties["firstname"].Value, sut.FirstName);
-            //Assert.Equal(sut.Properties["lastname"].Value, sut.LastName);
-            //Assert.Equal(sut.Properties["website"].Value, sut.Website);
-            //Assert.Equal(sut.Properties["company"].Value, sut.Company);
-            //Assert.Equal(sut.Properties["phone"].Value, sut.Phone);
-            //Assert.Equal(sut.Properties["address"].Value, sut.Address);
-            //Assert.Equal(sut.Properties["city"].Value, sut.City);
-            //Assert.Equal(sut.Properties["state"].Value, sut.State);
-            //Assert.Equal(sut.Properties["zip"].Value, sut.ZipCode);
-            Assert.True(sut.Properties["email"] == null || email == sut.Properties["email"].Value);
-            Assert.True(sut.Properties["firstname"] == null || fName == sut.Properties["firstname"].Value);
-            Assert.True(sut.Properties["lastname"] == null || lName == sut.Properties["lastname"].Value);
-            Assert.True(sut.Properties["website"] == null || site == sut.Properties["website"].Value);
-            Assert.True(sut.Properties["company"] == null || comp == sut.Properties["company"].Value);
-            Assert.True(sut.Properties["phone"] == null || phone == sut.Properties["phone"].Value);
-            Assert.True(sut.Properties["address"] == null || addr == sut.Properties["address"].Value);
-            Assert.True(sut.Properties["city"] == null || city == sut.Properties["city"].Value);
-            Assert.True(sut.Properties["state"] == null || state == sut.Properties["state"].Value);
-            Assert.True(sut.Properties["zip"] == null || zip == sut.Properties["zip"].Value);
+            sut.LoadProperties();
+
+            Assert.True(!sut.Properties.ContainsKey("email") || email == sut.Properties["email"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("firstname") || fName == sut.Properties["firstname"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("lastname") || lName == sut.Properties["lastname"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("website") || site == sut.Properties["website"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("company") || comp == sut.Properties["company"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("phone") || phone == sut.Properties["phone"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("address") || addr == sut.Properties["address"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("city") || city == sut.Properties["city"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("state") || state == sut.Properties["state"].Value as string);
+            Assert.True(!sut.Properties.ContainsKey("zip") || zip == sut.Properties["zip"].Value as string);
         }        
+
+        [Fact]
+        public void CustomContactModels_WillLoadTheirProperties_IntoThePropertiesDictionary_OnLoadProperties()
+        {
+            sut = new CustomContact("cheese", 5);
+
+            sut.LoadProperties();
+
+            Assert.True(sut.Properties.ContainsKey("flavor"));
+            Assert.True(sut.Properties.ContainsKey("legs"));
+
+            Assert.Equal("cheese", sut.Properties["flavor"].Value);
+            Assert.Equal(5, sut.Properties["legs"].Value);
+        }
     }
 }

--- a/HubSpot.NET.Tests/Api/Contact/Dto/ContactHSModelTests.cs
+++ b/HubSpot.NET.Tests/Api/Contact/Dto/ContactHSModelTests.cs
@@ -99,16 +99,26 @@ namespace HubSpot.NET.Tests.Api.Contact.Dto
                 ZipCode = zip
             };
 
-            Assert.Equal(sut.Properties["email"].Value, sut.Email);
-            Assert.Equal(sut.Properties["firstname"].Value, sut.FirstName);
-            Assert.Equal(sut.Properties["lastname"].Value, sut.LastName);
-            Assert.Equal(sut.Properties["website"].Value, sut.Website);
-            Assert.Equal(sut.Properties["company"].Value, sut.Company);
-            Assert.Equal(sut.Properties["phone"].Value, sut.Phone);
-            Assert.Equal(sut.Properties["address"].Value, sut.Address);
-            Assert.Equal(sut.Properties["city"].Value, sut.City);
-            Assert.Equal(sut.Properties["state"].Value, sut.State);
-            Assert.Equal(sut.Properties["zip"].Value, sut.ZipCode);
+            //Assert.Equal(sut.Properties["email"].Value, sut.Email);
+            //Assert.Equal(sut.Properties["firstname"].Value, sut.FirstName);
+            //Assert.Equal(sut.Properties["lastname"].Value, sut.LastName);
+            //Assert.Equal(sut.Properties["website"].Value, sut.Website);
+            //Assert.Equal(sut.Properties["company"].Value, sut.Company);
+            //Assert.Equal(sut.Properties["phone"].Value, sut.Phone);
+            //Assert.Equal(sut.Properties["address"].Value, sut.Address);
+            //Assert.Equal(sut.Properties["city"].Value, sut.City);
+            //Assert.Equal(sut.Properties["state"].Value, sut.State);
+            //Assert.Equal(sut.Properties["zip"].Value, sut.ZipCode);
+            Assert.True(sut.Properties["email"] == null || email == sut.Properties["email"].Value);
+            Assert.True(sut.Properties["firstname"] == null || fName == sut.Properties["firstname"].Value);
+            Assert.True(sut.Properties["lastname"] == null || lName == sut.Properties["lastname"].Value);
+            Assert.True(sut.Properties["website"] == null || site == sut.Properties["website"].Value);
+            Assert.True(sut.Properties["company"] == null || comp == sut.Properties["company"].Value);
+            Assert.True(sut.Properties["phone"] == null || phone == sut.Properties["phone"].Value);
+            Assert.True(sut.Properties["address"] == null || addr == sut.Properties["address"].Value);
+            Assert.True(sut.Properties["city"] == null || city == sut.Properties["city"].Value);
+            Assert.True(sut.Properties["state"] == null || state == sut.Properties["state"].Value);
+            Assert.True(sut.Properties["zip"] == null || zip == sut.Properties["zip"].Value);
         }        
     }
 }

--- a/HubSpot.NET.Tests/Api/Contact/Dto/ContactHSModelTests.cs
+++ b/HubSpot.NET.Tests/Api/Contact/Dto/ContactHSModelTests.cs
@@ -109,6 +109,6 @@ namespace HubSpot.NET.Tests.Api.Contact.Dto
             Assert.Equal(sut.Properties["city"].Value, sut.City);
             Assert.Equal(sut.Properties["state"].Value, sut.State);
             Assert.Equal(sut.Properties["zip"].Value, sut.ZipCode);
-        }
+        }        
     }
 }

--- a/HubSpot.NET.Tests/Api/Contact/Dto/ContactHSModelTests.cs
+++ b/HubSpot.NET.Tests/Api/Contact/Dto/ContactHSModelTests.cs
@@ -1,0 +1,114 @@
+﻿using HubSpot.NET.Api.Contact.Dto;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HubSpot.NET.Tests.Api.Contact.Dto
+{
+    [Collection("DTO Collection")]
+    public class ContactHSModelTests
+    {
+        private ContactHubSpotModel sut;
+
+        public ContactHSModelTests() { }
+
+        [Theory]
+        [InlineData("email@email.com",null, null, null, null, null, null, null, null, null)]
+        [InlineData("email@email.com","Firsty", null, null, null, null, null, null, null, null)]
+        [InlineData("email@email.com","Firsty", "Lasty", null, null, null, null, null, null, null)]
+        [InlineData("email@email.com","Firsty", "Lasty", "www.site.com", null, null, null, null, null, null)]
+        [InlineData("email@email.com","Firsty", "Lasty", "www.site.com", "Some Company", null, null, null, null, null)]
+        [InlineData("email@email.com","Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", null, null, null, null)]
+        [InlineData("email@email.com","Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", null, null, null)]
+        [InlineData("email@email.com","Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", "Nowhere", null, null)]
+        [InlineData("email@email.com","Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", "Nowhere", "Universe", null)]
+        [InlineData("email@email.com","Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", "Nowhere", "Universe", "12345")]
+        public void WhenPropertiesAssigned_ThroughConstructor_The_Values_Should_Be_In_Properties_Dictionary(string email, 
+                                                                                                            string fName, 
+                                                                                                            string lName, 
+                                                                                                            string site, 
+                                                                                                            string comp, 
+                                                                                                            string phone, 
+                                                                                                            string addr, 
+                                                                                                            string city,
+                                                                                                            string state,
+                                                                                                            string zip)
+        {
+            sut = new ContactHubSpotModel()
+            {
+                Email = email,
+                FirstName = fName,
+                LastName = lName,
+                Website = site,
+                Company = comp,
+                Phone = phone,
+                Address = addr,
+                City = city,
+                State = state,
+                ZipCode = zip
+            };
+
+            Assert.Equal(email, sut.Properties["email"].Value);
+            Assert.Equal(fName, sut.Properties["firstname"].Value);
+            Assert.Equal(lName, sut.Properties["lastname"].Value);
+            Assert.Equal(site, sut.Properties["website"].Value);
+            Assert.Equal(comp, sut.Properties["company"].Value);
+            Assert.Equal(phone, sut.Properties["phone"].Value);
+            Assert.Equal(addr, sut.Properties["address"].Value);
+            Assert.Equal(city, sut.Properties["city"].Value);
+            Assert.Equal(state, sut.Properties["state"].Value);
+            Assert.Equal(zip, sut.Properties["zip"].Value);
+        }
+
+        [Theory]
+        [InlineData("email@email.com", null, null, null, null, null, null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", null, null, null, null, null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", null, null, null, null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", null, null, null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", null, null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", "Nowhere", null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", "Nowhere", "Universe", null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", "Nowhere", "Universe", "12345")]
+        public void WhenPropertiesAssigned_ThroughConstructor_The_Values_In_PropertiesDictionary_Should_Match_object_properties(string email,
+                                                                                                    string fName,
+                                                                                                    string lName,
+                                                                                                    string site,
+                                                                                                    string comp,
+                                                                                                    string phone,
+                                                                                                    string addr,
+                                                                                                    string city,
+                                                                                                    string state,
+                                                                                                    string zip)
+        {
+            sut = new ContactHubSpotModel()
+            {
+                Email = email,
+                FirstName = fName,
+                LastName = lName,
+                Website = site,
+                Company = comp,
+                Phone = phone,
+                Address = addr,
+                City = city,
+                State = state,
+                ZipCode = zip
+            };
+
+            Assert.Equal(sut.Properties["email"].Value, sut.Email);
+            Assert.Equal(sut.Properties["firstname"].Value, sut.FirstName);
+            Assert.Equal(sut.Properties["lastname"].Value, sut.LastName);
+            Assert.Equal(sut.Properties["website"].Value, sut.Website);
+            Assert.Equal(sut.Properties["company"].Value, sut.Company);
+            Assert.Equal(sut.Properties["phone"].Value, sut.Phone);
+            Assert.Equal(sut.Properties["address"].Value, sut.Address);
+            Assert.Equal(sut.Properties["city"].Value, sut.City);
+            Assert.Equal(sut.Properties["state"].Value, sut.State);
+            Assert.Equal(sut.Properties["zip"].Value, sut.ZipCode);
+        }
+    }
+}

--- a/HubSpot.NET.Tests/Api/Contact/Dto/CreateOrUpdateTransportTest.cs
+++ b/HubSpot.NET.Tests/Api/Contact/Dto/CreateOrUpdateTransportTest.cs
@@ -53,16 +53,16 @@ namespace HubSpot.NET.Tests.Api.Contact.Dto
 
             var sut = new CreateOrUpdateContactTransportModel(payload);
 
-            Assert.Equal(email, sut.Properties.FirstOrDefault(x => x.Property == "email").Value);
-            Assert.Equal(fName, sut.Properties.FirstOrDefault(x => x.Property == "firstname").Value);
-            Assert.Equal(lName, sut.Properties.FirstOrDefault(x => x.Property == "lastname").Value);
-            Assert.Equal(site, sut.Properties.FirstOrDefault(x => x.Property == "website").Value);
-            Assert.Equal(comp, sut.Properties.FirstOrDefault(x => x.Property == "company").Value);
-            Assert.Equal(phone, sut.Properties.FirstOrDefault(x => x.Property == "phone").Value);
-            Assert.Equal(addr, sut.Properties.FirstOrDefault(x => x.Property == "address").Value);
-            Assert.Equal(city, sut.Properties.FirstOrDefault(x => x.Property == "city").Value);
-            Assert.Equal(state, sut.Properties.FirstOrDefault(x => x.Property == "state").Value);
-            Assert.Equal(zip, sut.Properties.FirstOrDefault(x => x.Property == "zip").Value);
+            Assert.True(sut.Properties["email"] == null || email == sut.Properties["email"].Value);
+            Assert.True(sut.Properties["firstname"] == null || fName == sut.Properties["firstname"].Value);
+            Assert.True(sut.Properties["lastname"] == null || lName == sut.Properties["lastname"].Value);
+            Assert.True(sut.Properties["webite"] == null || site == sut.Properties["website"].Value);
+            //Assert.Equal(comp, sut.Properties["company"].Value);
+            //Assert.Equal(phone, sut.Properties["phone"].Value);
+            //Assert.Equal(addr, sut.Properties["address"].Value);
+            //Assert.Equal(city, sut.Properties["city"].Value);
+            //Assert.Equal(state, sut.Properties["state"].Value);
+            //Assert.Equal(zip, sut.Properties["zip"].Value);
         }
 
         [Fact]

--- a/HubSpot.NET.Tests/Api/Contact/Dto/CreateOrUpdateTransportTest.cs
+++ b/HubSpot.NET.Tests/Api/Contact/Dto/CreateOrUpdateTransportTest.cs
@@ -56,13 +56,13 @@ namespace HubSpot.NET.Tests.Api.Contact.Dto
             Assert.True(sut.Properties["email"] == null || email == sut.Properties["email"].Value);
             Assert.True(sut.Properties["firstname"] == null || fName == sut.Properties["firstname"].Value);
             Assert.True(sut.Properties["lastname"] == null || lName == sut.Properties["lastname"].Value);
-            Assert.True(sut.Properties["webite"] == null || site == sut.Properties["website"].Value);
-            //Assert.Equal(comp, sut.Properties["company"].Value);
-            //Assert.Equal(phone, sut.Properties["phone"].Value);
-            //Assert.Equal(addr, sut.Properties["address"].Value);
-            //Assert.Equal(city, sut.Properties["city"].Value);
-            //Assert.Equal(state, sut.Properties["state"].Value);
-            //Assert.Equal(zip, sut.Properties["zip"].Value);
+            Assert.True(sut.Properties["website"] == null || site == sut.Properties["website"].Value);
+            Assert.True(sut.Properties["company"] == null || comp == sut.Properties["company"].Value);
+            Assert.True(sut.Properties["phone"] == null || phone == sut.Properties["phone"].Value);
+            Assert.True(sut.Properties["address"] == null || addr == sut.Properties["address"].Value);
+            Assert.True(sut.Properties["city"] == null || city == sut.Properties["city"].Value);
+            Assert.True(sut.Properties["state"] == null || state == sut.Properties["state"].Value);
+            Assert.True(sut.Properties["zip"] == null || zip == sut.Properties["zip"].Value);
         }
 
         [Fact]
@@ -73,9 +73,7 @@ namespace HubSpot.NET.Tests.Api.Contact.Dto
             var sut = new CreateOrUpdateContactTransportModel(payload);
 
             Assert.Equal(payload.Flavor, sut.Properties.Where(x => x.Property == "flavor").First().Value);
-
         }
-
     }
 
     internal class CustomContact : ContactHubSpotModel

--- a/HubSpot.NET.Tests/Api/Contact/Dto/CreateOrUpdateTransportTest.cs
+++ b/HubSpot.NET.Tests/Api/Contact/Dto/CreateOrUpdateTransportTest.cs
@@ -1,0 +1,97 @@
+﻿using HubSpot.NET.Api.Contact.Dto;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using Xunit;
+
+namespace HubSpot.NET.Tests.Api.Contact.Dto
+{
+    [Collection("DTO Collection")]
+    public class CreateOrUpdateContactTransportTest
+    {
+        private CreateOrUpdateContactTransportModel sut;
+
+        public CreateOrUpdateContactTransportTest() { }
+
+        [Theory]
+        [InlineData("email@email.com", null, null, null, null, null, null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", null, null, null, null, null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", null, null, null, null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", null, null, null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", null, null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", null, null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", null, null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", "Nowhere", null, null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", "Nowhere", "Universe", null)]
+        [InlineData("email@email.com", "Firsty", "Lasty", "www.site.com", "Some Company", "888-777-6655", "42 E Meanin of Life", "Nowhere", "Universe", "12345")]
+        public void AllContactProperties_Custom_Or_Otherwise_ShouldBeIn_Properties_Transport_Dictionary(string email,
+                                                                                                        string fName,
+                                                                                                        string lName,
+                                                                                                        string site,
+                                                                                                        string comp,
+                                                                                                        string phone,
+                                                                                                        string addr,
+                                                                                                        string city,
+                                                                                                        string state,
+                                                                                                        string zip)
+        {
+            var payload = new ContactHubSpotModel()
+            {
+                Email = email,
+                FirstName = fName,
+                LastName = lName,
+                Website = site,
+                Company = comp,
+                Phone = phone,
+                Address = addr,
+                City = city,
+                State = state,
+                ZipCode = zip
+            };
+
+            var sut = new CreateOrUpdateContactTransportModel(payload);
+
+            Assert.Equal(email, sut.Properties.FirstOrDefault(x => x.Property == "email").Value);
+            Assert.Equal(fName, sut.Properties.FirstOrDefault(x => x.Property == "firstname").Value);
+            Assert.Equal(lName, sut.Properties.FirstOrDefault(x => x.Property == "lastname").Value);
+            Assert.Equal(site, sut.Properties.FirstOrDefault(x => x.Property == "website").Value);
+            Assert.Equal(comp, sut.Properties.FirstOrDefault(x => x.Property == "company").Value);
+            Assert.Equal(phone, sut.Properties.FirstOrDefault(x => x.Property == "phone").Value);
+            Assert.Equal(addr, sut.Properties.FirstOrDefault(x => x.Property == "address").Value);
+            Assert.Equal(city, sut.Properties.FirstOrDefault(x => x.Property == "city").Value);
+            Assert.Equal(state, sut.Properties.FirstOrDefault(x => x.Property == "state").Value);
+            Assert.Equal(zip, sut.Properties.FirstOrDefault(x => x.Property == "zip").Value);
+        }
+
+        [Fact]
+        public void CustomContactClasses_Should_Have_Their_Properties_Injected_Into_The_Properties_Transport_Dictionary()
+        {
+            var payload = new CustomContact("goose", 40);
+
+            var sut = new CreateOrUpdateContactTransportModel(payload);
+
+            Assert.Equal(payload.Flavor, sut.Properties.Where(x => x.Property == "flavor").First().Value);
+
+        }
+
+    }
+
+    internal class CustomContact : ContactHubSpotModel
+    {
+        public CustomContact() : base()
+        { }
+
+        public CustomContact(string flavor, int legs): this()
+        {
+            Flavor = flavor;
+            NumberOfLegs = legs;
+        }
+
+        [DataMember(Name = "flavor")]
+        public string Flavor { get; set; } = string.Empty;
+        [DataMember(Name = "legs")]
+        public int NumberOfLegs { get; set; }
+    }
+}

--- a/HubSpot.NET.Tests/Api/ContactApiTests.cs
+++ b/HubSpot.NET.Tests/Api/ContactApiTests.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HubSpot.NET.Tests.Api
+{
+    public class ContactApiTests
+    {        
+
+    }
+}

--- a/HubSpot.NET.Tests/HubSpot.NET.Tests.csproj
+++ b/HubSpot.NET.Tests/HubSpot.NET.Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Api\" />
+    <ProjectReference Include="..\HubSpot.NET\HubSpot.NET.csproj" />
   </ItemGroup>
 
 </Project>

--- a/HubSpot.NET/Api/Contact/Dto/ContactHubSpotModel.cs
+++ b/HubSpot.NET/Api/Contact/Dto/ContactHubSpotModel.cs
@@ -25,9 +25,6 @@
         public string Email {
             set {
                 _Email = value;
-                //if (Properties.ContainsKey("email"))
-                //    Properties["email"].Value = value;
-
                 Properties["email"] = new ContactProperty(value);
             }
             get
@@ -43,8 +40,7 @@
         public string FirstName {
             set {
                 _FirstName = value;
-                if (Properties.ContainsKey("firstname"))
-                    Properties["firstname"].Value = value;
+                Properties["firstname"] = new ContactProperty(value);
             }
             get
             {
@@ -59,8 +55,7 @@
         public string LastName {
             set {
                 _LastName = value;
-                if (Properties.ContainsKey("lastname"))
-                    Properties["lastname"].Value = value;
+                Properties["lastname"] = new ContactProperty(value);
             }
             get
             {
@@ -75,8 +70,7 @@
         public string Website {
             set {
                 _Website = value;
-                if (Properties.ContainsKey("website"))
-                    Properties["website"].Value = value;
+                Properties["website"] = new ContactProperty(value);
             }
             get
             {
@@ -91,8 +85,7 @@
         public string Company {
             set {
                 _Company = value;
-                if (Properties.ContainsKey("company"))
-                    Properties["company"].Value = value;
+                Properties["company"] = new ContactProperty(value);
             }
             get
             {
@@ -107,8 +100,7 @@
         public string Phone {
             set {
                 _Phone = value;
-                if (Properties.ContainsKey("phone"))
-                    Properties["phone"].Value = value;
+                Properties["phone"] = new ContactProperty(value);
             }
             get
             {
@@ -122,9 +114,8 @@
         [DataMember(Name = "address")]
         public string Address {
             set {
-                _Address = value;
-                if (Properties.ContainsKey("address"))
-                    Properties["address"].Value = value;
+                _Address = value;                
+                Properties["address"] = new ContactProperty(value);
             }
             get
             {
@@ -138,9 +129,8 @@
         [DataMember(Name = "city")]
         public string City {
             set {
-                _City = value;
-                if (Properties.ContainsKey("city"))
-                    Properties["city"].Value = value;
+                _City = value;                
+                Properties["city"] = new ContactProperty(value);
             }
             get
             {
@@ -154,9 +144,8 @@
         [DataMember(Name = "state")]
         public string State {
             set {
-                _State = value;
-                if (Properties.ContainsKey("state"))
-                    Properties["state"].Value = value;
+                _State = value;                
+                Properties["state"] = new ContactProperty(value);
             }
             get
             {
@@ -172,9 +161,8 @@
         {
             set
             {
-                _ZipCode = value;
-                if (Properties.ContainsKey("zip"))
-                    Properties["zip"].Value = value;
+                _ZipCode = value;                
+                Properties["zip"] = new ContactProperty(value);
             }
             get
             {

--- a/HubSpot.NET/Api/Contact/Dto/ContactHubSpotModel.cs
+++ b/HubSpot.NET/Api/Contact/Dto/ContactHubSpotModel.cs
@@ -25,7 +25,7 @@
         public string Email {
             set {
                 _Email = value;
-                Properties["email"] = new ContactProperty(value);
+                //Properties["email"] = new ContactProperty(value);
             }
             get
             {
@@ -40,7 +40,7 @@
         public string FirstName {
             set {
                 _FirstName = value;
-                Properties["firstname"] = new ContactProperty(value);
+                //Properties["firstname"] = new ContactProperty(value);
             }
             get
             {
@@ -55,7 +55,7 @@
         public string LastName {
             set {
                 _LastName = value;
-                Properties["lastname"] = new ContactProperty(value);
+                //Properties["lastname"] = new ContactProperty(value);
             }
             get
             {
@@ -70,7 +70,7 @@
         public string Website {
             set {
                 _Website = value;
-                Properties["website"] = new ContactProperty(value);
+                //Properties["website"] = new ContactProperty(value);
             }
             get
             {
@@ -85,7 +85,7 @@
         public string Company {
             set {
                 _Company = value;
-                Properties["company"] = new ContactProperty(value);
+                //Properties["company"] = new ContactProperty(value);
             }
             get
             {
@@ -100,7 +100,7 @@
         public string Phone {
             set {
                 _Phone = value;
-                Properties["phone"] = new ContactProperty(value);
+                //Properties["phone"] = new ContactProperty(value);
             }
             get
             {
@@ -115,7 +115,7 @@
         public string Address {
             set {
                 _Address = value;                
-                Properties["address"] = new ContactProperty(value);
+                //Properties["address"] = new ContactProperty(value);
             }
             get
             {
@@ -130,7 +130,7 @@
         public string City {
             set {
                 _City = value;                
-                Properties["city"] = new ContactProperty(value);
+                //Properties["city"] = new ContactProperty(value);
             }
             get
             {
@@ -145,7 +145,7 @@
         public string State {
             set {
                 _State = value;                
-                Properties["state"] = new ContactProperty(value);
+                //Properties["state"] = new ContactProperty(value);
             }
             get
             {
@@ -162,7 +162,7 @@
             set
             {
                 _ZipCode = value;                
-                Properties["zip"] = new ContactProperty(value);
+                //Properties["zip"] = new ContactProperty(value);
             }
             get
             {

--- a/HubSpot.NET/Api/Contact/Dto/ContactHubSpotModel.cs
+++ b/HubSpot.NET/Api/Contact/Dto/ContactHubSpotModel.cs
@@ -3,6 +3,7 @@
     using HubSpot.NET.Core.Interfaces;
     using Newtonsoft.Json;
     using System.Collections.Generic;
+    using System.Reflection;
     using System.Runtime.Serialization;
 
     /// <summary>
@@ -13,6 +14,8 @@
     [DataContract]
     public class ContactHubSpotModel : IHubSpotModel
     {
+        public ContactHubSpotModel() { }
+
         /// <summary>
         /// Contacts unique ID in HubSpot
         /// </summary>
@@ -50,8 +53,28 @@
         [DataMember(Name = "hubspot_owner_id")]
         public long? OwnerId { get; set; }
 
+        // Used for return values
         [DataMember(Name = "properties")]
         public Dictionary<string, ContactProperty> Properties { get; set; } = new Dictionary<string, ContactProperty>();
+
+        /// <summary>
+        /// Loads all properties into the ContactProperty Dictionary even from custom contact models
+        /// </summary>
+        public void LoadProperties()
+        {
+            PropertyInfo[] properties = GetType().GetProperties();
+
+            foreach (PropertyInfo prop in properties)
+            {
+                var key = prop.GetCustomAttribute(typeof(DataMemberAttribute)) as DataMemberAttribute;
+                object value = prop.GetValue(this);
+
+                if (value == null || key == null || key.Name == "properties")
+                    continue;
+
+                Properties.Add(key.Name, new ContactProperty(value));
+            }
+        }
 
         [IgnoreDataMember]
         public bool IsNameValue => false;

--- a/HubSpot.NET/Api/Contact/Dto/ContactHubSpotModel.cs
+++ b/HubSpot.NET/Api/Contact/Dto/ContactHubSpotModel.cs
@@ -29,8 +29,8 @@
             }
             get
             {
-                if (string.IsNullOrWhiteSpace(_Email))
-                { _Email = Properties.ContainsKey("email") ? Properties["email"].Value : string.Empty; }
+                //if (string.IsNullOrWhiteSpace(_Email))
+                //{ _Email = Properties.ContainsKey("email") ? Properties["email"].Value : string.Empty; }
                 return _Email;
             }
         }
@@ -44,8 +44,8 @@
             }
             get
             {
-                if(string.IsNullOrWhiteSpace(_FirstName))
-                { _FirstName = Properties.ContainsKey("firstname") ? Properties["firstname"].Value : string.Empty; }
+                //if(string.IsNullOrWhiteSpace(_FirstName))
+                //{ _FirstName = Properties.ContainsKey("firstname") ? Properties["firstname"].Value : string.Empty; }
                 return _FirstName;
             }
         }
@@ -59,8 +59,8 @@
             }
             get
             {
-                if(string.IsNullOrWhiteSpace(_LastName))
-                { _LastName = Properties.ContainsKey("lastname") ? Properties["lastname"].Value : string.Empty; }
+                //if(string.IsNullOrWhiteSpace(_LastName))
+                //{ _LastName = Properties.ContainsKey("lastname") ? Properties["lastname"].Value : string.Empty; }
                 return _LastName;
             }
         }
@@ -74,8 +74,8 @@
             }
             get
             {
-                if(string.IsNullOrWhiteSpace(_Website))
-                { _Website = Properties.ContainsKey("website") ? Properties["website"].Value : string.Empty; }
+                //if(string.IsNullOrWhiteSpace(_Website))
+                //{ _Website = Properties.ContainsKey("website") ? Properties["website"].Value : string.Empty; }
                 return _Website;
             }
         }
@@ -89,8 +89,8 @@
             }
             get
             {
-                if(string.IsNullOrWhiteSpace(_Company))
-                { _Company = Properties.ContainsKey("company") ? Properties["company"].Value : string.Empty; }
+                //if(string.IsNullOrWhiteSpace(_Company))
+                //{ _Company = Properties.ContainsKey("company") ? Properties["company"].Value : string.Empty; }
                 return _Company;
             }
         }
@@ -104,8 +104,8 @@
             }
             get
             {
-                if(string.IsNullOrWhiteSpace(_Phone))
-                { _Phone = Properties.ContainsKey("phone") ? Properties["phone"].Value : string.Empty; }
+                //if(string.IsNullOrWhiteSpace(_Phone))
+                //{ _Phone = Properties.ContainsKey("phone") ? Properties["phone"].Value : string.Empty; }
                 return _Phone;
             }
         }
@@ -119,8 +119,8 @@
             }
             get
             {
-                if(string.IsNullOrWhiteSpace(_Address))
-                { _Address = Properties.ContainsKey("address") ? Properties["address"].Value : string.Empty; }
+                //if(string.IsNullOrWhiteSpace(_Address))
+                //{ _Address = Properties.ContainsKey("address") ? Properties["address"].Value : string.Empty; }
                 return _Address;
             }
         }
@@ -134,8 +134,8 @@
             }
             get
             {
-                if (string.IsNullOrWhiteSpace(_City))
-                { _City = Properties.ContainsKey("city") ? Properties["city"].Value : string.Empty; }
+                //if (string.IsNullOrWhiteSpace(_City))
+                //{ _City = Properties.ContainsKey("city") ? Properties["city"].Value : string.Empty; }
                 return _City;
             }
         }
@@ -149,8 +149,8 @@
             }
             get
             {
-                if(string.IsNullOrWhiteSpace(_State))
-                { _State = Properties.ContainsKey("state") ? Properties["state"].Value : string.Empty; }
+                //if(string.IsNullOrWhiteSpace(_State))
+                //{ _State = Properties.ContainsKey("state") ? Properties["state"].Value : string.Empty; }
                 return _State;
             }
         }
@@ -166,8 +166,8 @@
             }
             get
             {
-                if (string.IsNullOrWhiteSpace(_ZipCode))
-                { _ZipCode = Properties.ContainsKey("zip") ? Properties["zip"].Value : string.Empty; }
+                //if (string.IsNullOrWhiteSpace(_ZipCode))
+                //{ _ZipCode = Properties.ContainsKey("zip") ? Properties["zip"].Value : string.Empty; }
                 return _ZipCode;
             }
         }

--- a/HubSpot.NET/Api/Contact/Dto/ContactHubSpotModel.cs
+++ b/HubSpot.NET/Api/Contact/Dto/ContactHubSpotModel.cs
@@ -19,158 +19,30 @@
         [DataMember(Name = "vid")]
         [IgnoreDataMember]
         public long? Id { get; set; }
-
-        private string _Email;
+        
         [DataMember(Name = "email")]
-        public string Email {
-            set {
-                _Email = value;
-                //Properties["email"] = new ContactProperty(value);
-            }
-            get
-            {
-                //if (string.IsNullOrWhiteSpace(_Email))
-                //{ _Email = Properties.ContainsKey("email") ? Properties["email"].Value : string.Empty; }
-                return _Email;
-            }
-        }
-
-        private string _FirstName;
+        public string Email { get; set; }
+        
         [DataMember(Name = "firstname")]
-        public string FirstName {
-            set {
-                _FirstName = value;
-                //Properties["firstname"] = new ContactProperty(value);
-            }
-            get
-            {
-                //if(string.IsNullOrWhiteSpace(_FirstName))
-                //{ _FirstName = Properties.ContainsKey("firstname") ? Properties["firstname"].Value : string.Empty; }
-                return _FirstName;
-            }
-        }
-
-        private string _LastName;
+        public string FirstName { get; set; }
+        
         [DataMember(Name = "lastname")]
-        public string LastName {
-            set {
-                _LastName = value;
-                //Properties["lastname"] = new ContactProperty(value);
-            }
-            get
-            {
-                //if(string.IsNullOrWhiteSpace(_LastName))
-                //{ _LastName = Properties.ContainsKey("lastname") ? Properties["lastname"].Value : string.Empty; }
-                return _LastName;
-            }
-        }
-
-        private string _Website;
+        public string LastName { get; set; }
+        
         [DataMember(Name = "website")]
-        public string Website {
-            set {
-                _Website = value;
-                //Properties["website"] = new ContactProperty(value);
-            }
-            get
-            {
-                //if(string.IsNullOrWhiteSpace(_Website))
-                //{ _Website = Properties.ContainsKey("website") ? Properties["website"].Value : string.Empty; }
-                return _Website;
-            }
-        }
-
-        private string _Company;
+        public string Website { get; set; }
         [DataMember(Name = "company")]
-        public string Company {
-            set {
-                _Company = value;
-                //Properties["company"] = new ContactProperty(value);
-            }
-            get
-            {
-                //if(string.IsNullOrWhiteSpace(_Company))
-                //{ _Company = Properties.ContainsKey("company") ? Properties["company"].Value : string.Empty; }
-                return _Company;
-            }
-        }
-
-        private string _Phone;
+        public string Company { set; get; }
         [DataMember(Name = "phone")]
-        public string Phone {
-            set {
-                _Phone = value;
-                //Properties["phone"] = new ContactProperty(value);
-            }
-            get
-            {
-                //if(string.IsNullOrWhiteSpace(_Phone))
-                //{ _Phone = Properties.ContainsKey("phone") ? Properties["phone"].Value : string.Empty; }
-                return _Phone;
-            }
-        }
-
-        private string _Address;
+        public string Phone { set; get; }
         [DataMember(Name = "address")]
-        public string Address {
-            set {
-                _Address = value;                
-                //Properties["address"] = new ContactProperty(value);
-            }
-            get
-            {
-                //if(string.IsNullOrWhiteSpace(_Address))
-                //{ _Address = Properties.ContainsKey("address") ? Properties["address"].Value : string.Empty; }
-                return _Address;
-            }
-        }
-
-        private string _City;
+        public string Address { set; get; }
         [DataMember(Name = "city")]
-        public string City {
-            set {
-                _City = value;                
-                //Properties["city"] = new ContactProperty(value);
-            }
-            get
-            {
-                //if (string.IsNullOrWhiteSpace(_City))
-                //{ _City = Properties.ContainsKey("city") ? Properties["city"].Value : string.Empty; }
-                return _City;
-            }
-        }
-
-        private string _State;
+        public string City { set; get; }
         [DataMember(Name = "state")]
-        public string State {
-            set {
-                _State = value;                
-                //Properties["state"] = new ContactProperty(value);
-            }
-            get
-            {
-                //if(string.IsNullOrWhiteSpace(_State))
-                //{ _State = Properties.ContainsKey("state") ? Properties["state"].Value : string.Empty; }
-                return _State;
-            }
-        }
-
-        private string _ZipCode;
+        public string State { set; get; }
         [DataMember(Name = "zip")]
-        public string ZipCode
-        {
-            set
-            {
-                _ZipCode = value;                
-                //Properties["zip"] = new ContactProperty(value);
-            }
-            get
-            {
-                //if (string.IsNullOrWhiteSpace(_ZipCode))
-                //{ _ZipCode = Properties.ContainsKey("zip") ? Properties["zip"].Value : string.Empty; }
-                return _ZipCode;
-            }
-        }
+        public string ZipCode { set; get; }
 
         [DataMember(Name = "associatedcompanyid")]
         public long? AssociatedCompanyId { get; set; }

--- a/HubSpot.NET/Api/Contact/Dto/ContactProperty.cs
+++ b/HubSpot.NET/Api/Contact/Dto/ContactProperty.cs
@@ -10,13 +10,13 @@ namespace HubSpot.NET.Api.Contact.Dto
     {
         public ContactProperty() { }
 
-        public ContactProperty(string value)
+        public ContactProperty(object value)
         {
             Value = value;
         }
 
         [DataMember(Name = "value")]
-        public string Value { get; set; }
+        public object Value { get; set; }
 
         [DataMember(Name = "versions")]
         List<ContactPropertyVersion> Versions { get; set; } = new List<ContactPropertyVersion>();

--- a/HubSpot.NET/Api/Contact/Dto/CreateOrUpdateContactTransportModel.cs
+++ b/HubSpot.NET/Api/Contact/Dto/CreateOrUpdateContactTransportModel.cs
@@ -4,7 +4,7 @@
     using System.Runtime.Serialization;
 
     [DataContract]
-    public class CreateOrUpdateContactTransportModel : PropertyTransportManager<ContactHubSpotModel>
+    public class CreateOrUpdateContactTransportModel : PropertyTransport<ContactHubSpotModel>
     {
         public CreateOrUpdateContactTransportModel() { }
 

--- a/HubSpot.NET/Api/Contact/Dto/CreateOrUpdateContactTransportModel.cs
+++ b/HubSpot.NET/Api/Contact/Dto/CreateOrUpdateContactTransportModel.cs
@@ -4,7 +4,7 @@
     using System.Runtime.Serialization;
 
     [DataContract]
-    public class CreateOrUpdateContactTransportModel : PropertyTransportModel<ContactHubSpotModel>
+    public class CreateOrUpdateContactTransportModel : PropertyTransportManager<ContactHubSpotModel>
     {
         public CreateOrUpdateContactTransportModel() { }
 

--- a/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
+++ b/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
@@ -32,7 +32,7 @@ namespace HubSpot.NET.Api.Contact
             CreateOrUpdateContactTransportModel transport = new CreateOrUpdateContactTransportModel(entity);
             string path = GetRoute<ContactHubSpotModel>("contact");
 
-            return _client.Execute<ContactHubSpotModel,CreateOrUpdateContactTransportModel>(path, transport, Method.POST);
+            return _client.Execute<ContactHubSpotModel, CreateOrUpdateContactTransportModel>(path, transport, Method.POST);
         }
 
         /// <summary>

--- a/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
+++ b/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
@@ -74,7 +74,6 @@ namespace HubSpot.NET.Api.Contact
             if(IncludeHistory)
             {
                 return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact","vid", contactId.ToString(),"profile"));
-
             }
             else
             {
@@ -82,10 +81,7 @@ namespace HubSpot.NET.Api.Contact
             }
         }
 
-        public ContactHubSpotModel GetById(long Id)
-        {
-            return GetById(Id, true);
-        }
+        public ContactHubSpotModel GetById(long Id) => GetById(Id, true);
 
         /// <summary>
         /// Gets a contact by their email address

--- a/HubSpot.NET/Api/Owner/Dto/OwnerListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Owner/Dto/OwnerListHubSpotModel.cs
@@ -20,8 +20,7 @@ namespace HubSpot.NET.Api.Owner.Dto
         public IEnumerator<T> GetEnumerator() 
             => Owners.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator() 
-            => GetEnumerator();
+        IEnumerator IEnumerable.Enumerator => GetEnumerator();
 
         public void Add(T item) 
             => Owners.Add(item);

--- a/HubSpot.NET/Api/Owner/Dto/OwnerListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Owner/Dto/OwnerListHubSpotModel.cs
@@ -20,7 +20,7 @@ namespace HubSpot.NET.Api.Owner.Dto
         public IEnumerator<T> GetEnumerator() 
             => Owners.GetEnumerator();
 
-        IEnumerator IEnumerable.Enumerator => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         public void Add(T item) 
             => Owners.Add(item);

--- a/HubSpot.NET/Api/Properties/Dto/PropertiesListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Properties/Dto/PropertiesListHubSpotModel.cs
@@ -20,8 +20,7 @@ namespace HubSpot.NET.Api.Properties.Dto
         public IEnumerator<T> GetEnumerator() 
             => Properties.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator() 
-            => GetEnumerator();
+        IEnumerator IEnumerable.Enumerator => GetEnumerator();
 
         public void Add(T item) 
             => Properties.Add(item);

--- a/HubSpot.NET/Api/Properties/Dto/PropertiesListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Properties/Dto/PropertiesListHubSpotModel.cs
@@ -20,7 +20,7 @@ namespace HubSpot.NET.Api.Properties.Dto
         public IEnumerator<T> GetEnumerator() 
             => Properties.GetEnumerator();
 
-        IEnumerator IEnumerable.Enumerator => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         public void Add(T item) 
             => Properties.Add(item);

--- a/HubSpot.NET/Api/Shared/LabelValuePair.cs
+++ b/HubSpot.NET/Api/Shared/LabelValuePair.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.Serialization;
 
-namespace HubSpot.NET.Api.Contact.Dto
+namespace HubSpot.NET.Api.Shared
 {
     [DataContract]
     public class LabelValuePair

--- a/HubSpot.NET/Api/Shared/PropertyTransportModel.cs
+++ b/HubSpot.NET/Api/Shared/PropertyTransportModel.cs
@@ -6,7 +6,7 @@
     using System.Runtime.Serialization;
 
     [DataContract]
-    public abstract class PropertyTransportManager<T>
+    public abstract class PropertyTransport<T>
     {
         [DataMember(Name = "properties")]
         public PropertyValuePairCollection Properties { get; set; } = new PropertyValuePairCollection();
@@ -45,14 +45,6 @@
                 Properties.Add(new PropertyValuePair(memberAttrib.Name, value.ToString()));
             }
         }
-
-        //public void ToPropertyTransportModel(ContactHubSpotModel model)
-        //{
-        //    foreach (KeyValuePair<string, ContactProperty> pair in model.Properties)
-        //    {
-        //        Properties.Add(new PropertyValuePair() { Property = pair.Key, Value = pair.Value.Value });
-        //    }
-        //}
 
         public void FromPropertyTransportModel(out T model)
         {

--- a/HubSpot.NET/Api/Shared/PropertyTransportModel.cs
+++ b/HubSpot.NET/Api/Shared/PropertyTransportModel.cs
@@ -6,7 +6,7 @@
     using System.Runtime.Serialization;
 
     [DataContract]
-    public abstract class PropertyTransportModel<T>
+    public abstract class PropertyTransportManager<T>
     {
         [DataMember(Name = "properties")]
         public PropertyValuePairCollection Properties { get; set; } = new PropertyValuePairCollection();

--- a/HubSpot.NET/Api/Shared/PropertyTransportModel.cs
+++ b/HubSpot.NET/Api/Shared/PropertyTransportModel.cs
@@ -20,10 +20,8 @@
                 var memberAttrib = prop.GetCustomAttribute(typeof(DataMemberAttribute)) as DataMemberAttribute;
                 object value = prop.GetValue(model);
 
-                if (value == null || memberAttrib == null)
-                {
-                    continue;
-                }
+                if (value == null || memberAttrib == null)                
+                    continue;                
 
                 if (prop.PropertyType.IsArray && typeof(PropertyValuePair).IsAssignableFrom(prop.PropertyType.GetElementType()))
                 {

--- a/HubSpot.NET/Api/Shared/PropertyTransportModel.cs
+++ b/HubSpot.NET/Api/Shared/PropertyTransportModel.cs
@@ -9,8 +9,7 @@
     public abstract class PropertyTransportModel<T>
     {
         [DataMember(Name = "properties")]
-        public List<PropertyValuePair> Properties { get; set; } = new List<PropertyValuePair>();
-
+        public PropertyValuePairCollection Properties { get; set; } = new PropertyValuePairCollection();
         
         public void ToPropertyTransportModel(T model)
         {
@@ -29,27 +28,33 @@
                 if (prop.PropertyType.IsArray && typeof(PropertyValuePair).IsAssignableFrom(prop.PropertyType.GetElementType()))
                 {
                     PropertyValuePair[] pairs = value as PropertyValuePair[];
-                    Properties.AddRange(pairs);
+                    foreach (var item in pairs)
+                    {
+                        Properties.Add(item);
+                    }
                     continue;
                 }
                 else if(typeof(IEnumerable<>).IsAssignableFrom(prop.PropertyType) && typeof(PropertyValuePair).IsAssignableFrom(prop.PropertyType.GetElementType()))
                 {
                     IEnumerable<PropertyValuePair> pairs = value as IEnumerable<PropertyValuePair>;
-                    Properties.AddRange(pairs);
+                    foreach (var item in pairs)
+                    {
+                        Properties.Add(item);
+                    }
                     continue;
                 }
 
-                Properties.Add(new PropertyValuePair() { Property = memberAttrib.Name, Value = value.ToString() });
+                Properties.Add(new PropertyValuePair(memberAttrib.Name, value.ToString()));
             }
         }
 
-        public void ToPropertyTransportModel(ContactHubSpotModel model)
-        {
-            foreach(KeyValuePair<string, ContactProperty> pair in model.Properties)
-            {
-                Properties.Add(new PropertyValuePair() { Property = pair.Key, Value = pair.Value.Value });
-            }
-        }
+        //public void ToPropertyTransportModel(ContactHubSpotModel model)
+        //{
+        //    foreach (KeyValuePair<string, ContactProperty> pair in model.Properties)
+        //    {
+        //        Properties.Add(new PropertyValuePair() { Property = pair.Key, Value = pair.Value.Value });
+        //    }
+        //}
 
         public void FromPropertyTransportModel(out T model)
         {
@@ -61,7 +66,7 @@
             {
                 var memberAttrib = prop.GetCustomAttribute(typeof(DataMemberAttribute)) as DataMemberAttribute;
 
-                PropertyValuePair pair = Properties.Find(x => x.Property == memberAttrib.Name);
+                PropertyValuePair pair = Properties[memberAttrib.Name];
                 prop.SetValue(model, pair.Value);
             }
         }

--- a/HubSpot.NET/Api/Shared/PropertyValuePair.cs
+++ b/HubSpot.NET/Api/Shared/PropertyValuePair.cs
@@ -5,6 +5,13 @@
     [DataContract]
     public class PropertyValuePair
     {
+        public PropertyValuePair() { }
+        public PropertyValuePair(string prop, string value) : this()
+        {
+            Property = prop;
+            Value = value;
+        }
+
         [DataMember(Name = "property")]
         public string Property { get; set; }
 

--- a/HubSpot.NET/Api/Shared/PropertyValuePair.cs
+++ b/HubSpot.NET/Api/Shared/PropertyValuePair.cs
@@ -17,5 +17,7 @@
 
         [DataMember(Name = "value")]
         public string Value { get; set; }
+
+        public override string ToString() => $"{Property}: {Value}";
     }
 }

--- a/HubSpot.NET/Api/Shared/PropertyValuePairCollections.cs
+++ b/HubSpot.NET/Api/Shared/PropertyValuePairCollections.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace HubSpot.NET.Api.Shared
+{
+    public class PropertyValuePairCollection : ICollection<PropertyValuePair>
+    {
+        public List<PropertyValuePair> Properties { get; set; } = new List<PropertyValuePair>();        
+
+        public int Count => Properties.Count;
+
+        public bool IsReadOnly => false;
+
+        public PropertyValuePair this[string index]
+        {
+            get => Properties.FirstOrDefault(x => x.Property == index);
+            set => this[index] = value;
+        }
+
+        public void Add(PropertyValuePair item) => Properties.Add(item);
+        public void Clear() => Properties.Clear();
+        public bool Contains(PropertyValuePair item) => Properties.Contains(item);
+        public void CopyTo(PropertyValuePair[] array, int arrayIndex) => Properties.CopyTo(array, arrayIndex);
+        public bool Remove(PropertyValuePair item) => Properties.Remove(item);
+        public IEnumerator<PropertyValuePair> GetEnumerator() => Properties.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => Properties.GetEnumerator();
+    }
+}


### PR DESCRIPTION
Most of the work in here is to make a way for HubSpotModels and custom contact models to automatically have their properties transformed into the Property Value Pair format when sent for CreateOrUpdate on the Contacts API.

This includes a methodology of simply using auto properties in ContactHubSpotModels and custom contact models.

Additionally, I created the Unit test library and started making tests specifically for this properties issue. This PR addresses #37