### PR TITLE
Changed HubSpot.NET from a .NET Framework class library to .NET Standard 2.0 class library.

### DIFF
--- a/HubSpot.NET.Examples/HubSpot.NET.Examples.csproj
+++ b/HubSpot.NET.Examples/HubSpot.NET.Examples.csproj
@@ -32,8 +32,27 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Flurl, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Flurl.2.6.0\lib\net45\Flurl.dll</HintPath>
+    </Reference>
+    <Reference Include="HubSpot.NET, Version=0.5.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\HubSpot.NET\bin\Debug\netstandard2.0\HubSpot.NET.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp, Version=106.6.10.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.6.10\lib\net452\RestSharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -53,12 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\HubSpot.NET\HubSpot.NET.csproj">
-      <Project>{2D45B6F1-77AE-427E-846B-75BB380BE93B}</Project>
-      <Name>HubSpot.NET</Name>
-    </ProjectReference>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/HubSpot.NET.Examples/packages.config
+++ b/HubSpot.NET.Examples/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Flurl" version="2.6.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
+  <package id="NuGet.CommandLine" version="1.0.11220.26" targetFramework="net461" />
+  <package id="RestSharp" version="106.6.10" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
+</packages>

--- a/HubSpot.NET.sln
+++ b/HubSpot.NET.sln
@@ -1,11 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.352
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HubSpot.NET", "HubSpot.NET\HubSpot.NET.csproj", "{2D45B6F1-77AE-427E-846B-75BB380BE93B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HubSpot.NET", "HubSpot.NET\HubSpot.NET.csproj", "{2D45B6F1-77AE-427E-846B-75BB380BE93B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HubSpot.NET.Examples", "HubSpot.NET.Examples\HubSpot.NET.Examples.csproj", "{AE1AABCC-388E-43A3-B58D-5BD566C3438B}"
+	ProjectSection(ProjectDependencies) = postProject
+		{2D45B6F1-77AE-427E-846B-75BB380BE93B} = {2D45B6F1-77AE-427E-846B-75BB380BE93B}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>0.5.1</Version>
     <Authors>Squared Up Ltd.</Authors>
@@ -24,13 +24,24 @@
   <ItemGroup>
     <PackageReference Include="Flurl" Version="2.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="RestSharp" Version="105.2.3" />
+    <PackageReference Include="RestSharp" Version="106.6.10" />
+	<PackageReference Include="NuGet.CommandLine" Version="1.0.11220.26" />
+	<PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
 </Project>
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
**Issue:** Current HubSpot.NET class library is not compatible with .NET Core since the target framework is .NET Framework. 

**Solution**: After modifying the class library to .NET Standard 2.0, it is now compatible with .NET Framework and .NET Core projects.