### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/HubSpot.NET/Api/EmailEvents/HubSpotEmailEventsApi.cs
+++ b/HubSpot.NET/Api/EmailEvents/HubSpotEmailEventsApi.cs
@@ -31,7 +31,7 @@ namespace HubSpot.NET.Api.EmailEvents
         {
             var path = $"{(new T()).RouteBasePath}/{campaignId}"
                 .SetQueryParam("appId", appId);
-            var data = _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: false);
+            var data = _client.Execute<T>(path, Method.GET);
             return data;
         }
 
@@ -56,7 +56,7 @@ namespace HubSpot.NET.Api.EmailEvents
                 path = path.SetQueryParam("offset", opts.Offset);
             }
 
-            var data = _client.ExecuteList<EmailCampaignListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: false);
+            var data = _client.Execute<EmailCampaignListHubSpotModel<T>>(path);
 
             return data;
         }
@@ -82,7 +82,7 @@ namespace HubSpot.NET.Api.EmailEvents
                 path = path.SetQueryParam("offset", opts.Offset);
             }
 
-            var data = _client.ExecuteList<EmailCampaignListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: false);
+            var data = _client.Execute<EmailCampaignListHubSpotModel<T>>(path);
 
             return data;
         }

--- a/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
+++ b/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
@@ -53,7 +53,7 @@ namespace HubSpot.NET.Api.Engagement
         /// <returns>List of engagements, with additional metadata, e.g. total</returns>
         public EngagementListHubSpotModel<T> List<T>(EngagementListRequestOptions opts = null) where T: EngagementHubSpotModel
         {
-            opts =  opts ?? new EngagementListRequestOptions();
+            opts ??= new EngagementListRequestOptions();
 
             var path = $"{GetRoute<T>("paged")}".SetQueryParam("limit", opts.Limit);
 
@@ -105,7 +105,7 @@ namespace HubSpot.NET.Api.Engagement
         /// <returns>List of associated engagements</returns>
         public EngagementListHubSpotModel<T> ListAssociated<T>(long objectId, string objectType, EngagementListRequestOptions opts = null) where T: EngagementHubSpotModel
         {
-            opts = opts ?? new EngagementListRequestOptions();
+            opts ??= new EngagementListRequestOptions();
             
             var path = $"{GetRoute<T>()}/engagements/associated/{objectType}/{objectId}/paged".SetQueryParam("limit", opts.Limit);
 

--- a/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
+++ b/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
@@ -53,7 +53,7 @@ namespace HubSpot.NET.Api.Engagement
         /// <returns>List of engagements, with additional metadata, e.g. total</returns>
         public EngagementListHubSpotModel<T> List<T>(EngagementListRequestOptions opts = null) where T: EngagementHubSpotModel
         {
-            opts ??= new EngagementListRequestOptions();
+            opts = opts ?? new EngagementListRequestOptions();
 
             var path = $"{GetRoute<T>("paged")}".SetQueryParam("limit", opts.Limit);
 
@@ -70,7 +70,7 @@ namespace HubSpot.NET.Api.Engagement
         /// <returns>List of engagements, with additional metadata, e.g. total</returns>
         public EngagementListHubSpotModel<T> ListRecent<T>(EngagementListRequestOptions opts = null) where T : EngagementHubSpotModel
         {
-            opts ??= new EngagementListRequestOptions();
+            opts = opts ?? new EngagementListRequestOptions();
 
             var path = $"{GetRoute<T>()}/engagements/recent/modified".SetQueryParam("count", opts.Limit);
 
@@ -105,7 +105,7 @@ namespace HubSpot.NET.Api.Engagement
         /// <returns>List of associated engagements</returns>
         public EngagementListHubSpotModel<T> ListAssociated<T>(long objectId, string objectType, EngagementListRequestOptions opts = null) where T: EngagementHubSpotModel
         {
-            opts ??= new EngagementListRequestOptions();
+            opts = opts ?? new EngagementListRequestOptions();
             
             var path = $"{GetRoute<T>()}/engagements/associated/{objectType}/{objectId}/paged".SetQueryParam("limit", opts.Limit);
 

--- a/HubSpot.NET/Core/HubSpotApi.cs
+++ b/HubSpot.NET/Core/HubSpotApi.cs
@@ -3,6 +3,7 @@
     using HubSpot.NET.Api.Company;
     using HubSpot.NET.Api.Contact;
     using HubSpot.NET.Api.Deal;
+    using HubSpot.NET.Api.EmailEvents;
     using HubSpot.NET.Api.EmailSubscriptions;
     using HubSpot.NET.Api.Engagement;
     using HubSpot.NET.Api.Files;
@@ -27,7 +28,7 @@
         public IHubSpotCosFileApi File { get; private set; }
         public IHubSpotOwnerApi Owner { get; private set; }
         public IHubSpotCompanyPropertiesApi CompanyProperties { get; private set; }
-
+        public IHubSpotEmailEventsApi EmailEvents { get; private set; }
         public IHubSpotEmailSubscriptionsApi EmailSubscriptions { get; private set; }
         public IHubSpotTimelineApi Timelines { get; private set; }
 

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net461</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>0.8.13</Version>
     <Authors>HubSpot.NET</Authors>
@@ -16,10 +16,10 @@
     <PackageId>HubSpot.NET</PackageId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Flurl" Version="2.8.0" />

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -8,7 +8,7 @@
     <Company>HubSpot.NET</Company>
     <Description>C# .NET client library targeting the HubSpot APIs.</Description>
     <Copyright>HubSpot.NET</Copyright>
-    <PackageLicenseUrl>https://github.com/squaredup/HubSpot.NET/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/hubspot-net/HubSpot.NET/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/hubspot-net/HubSpot.NET</PackageProjectUrl>
     <RepositoryUrl>https://github.com/hubspot-net/HubSpot.NET.git</RepositoryUrl>
     <PackageTags>hubspot api wrapper c# contact company deal engagement properties crm</PackageTags>

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>0.8.13</Version>
     <Authors>HubSpot.NET</Authors>
@@ -16,10 +16,10 @@
     <PackageId>HubSpot.NET</PackageId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Flurl" Version="2.8.0" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,34 @@
+# ASP.NET Core (.NET Framework)
+# Build and test ASP.NET Core projects targeting the full .NET Framework.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+
+trigger:
+- master
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: NuGetToolInstaller@1
+
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(solution)'
+
+- task: VSBuild@1
+  inputs:
+    solution: '$(solution)'
+    msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:DesktopBuildPackageLocation="$(build.artifactStagingDirectory)\WebApp.zip" /p:DeployIisAppPath="Default Web Site"'
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+
+- task: VSTest@2
+  inputs:
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,12 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
+  branches:
+    include:
+    - master
+    - refs/tags/*
+  
+pr:
 - master
 
 pool:


### PR DESCRIPTION
The PR is simply to set up automated builds with Azure Pipelines and remove C# 8 features from the Engagement API until a time when supporting .NET Standard 2.1 is considered.