### PR TITLE
Added better 404 (not found) handling if calling a GetByX method.

### DIFF
--- a/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
+++ b/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
@@ -1,15 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Flurl;
-using HubSpot.NET.Api.Contact.Dto;
-using HubSpot.NET.Core;
-using HubSpot.NET.Core.Abstracts;
-using HubSpot.NET.Core.Interfaces;
-using RestSharp;
-
-namespace HubSpot.NET.Api.Contact
+﻿namespace HubSpot.NET.Api.Contact
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using Flurl;
+    using HubSpot.NET.Api.Contact.Dto;
+    using HubSpot.NET.Core;
+    using HubSpot.NET.Core.Abstracts;
+    using HubSpot.NET.Core.Interfaces;
+    using RestSharp;
+
     public class HubSpotContactApi : ApiRoutable, IHubSpotContactApi
     {
         private readonly IHubSpotClient _client;
@@ -71,13 +72,22 @@ namespace HubSpot.NET.Api.Contact
         /// <returns>The contact entity</returns>
         public ContactHubSpotModel GetById(long contactId, bool IncludeHistory = true)
         {
-            if(IncludeHistory)
+            try
             {
-                return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact","vid", contactId.ToString(),"profile"));
+                if (IncludeHistory)
+                {
+                    return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact","vid", contactId.ToString(),"profile"));
+                }
+                else
+                {
+                    return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact", "vid", contactId.ToString(), "profile?propertyMode=value_only"));
+                }
             }
-            else
+            catch (HubSpotException exception)
             {
-                return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact", "vid", contactId.ToString(), "profile?propertyMode=value_only"));
+                if (exception.ReturnedError.StatusCode == HttpStatusCode.NotFound)
+                    return null;
+                throw;
             }
         }
 
@@ -91,13 +101,22 @@ namespace HubSpot.NET.Api.Contact
         /// <returns>The contact entity</returns>
         public ContactHubSpotModel GetByEmail(string email, bool IncludeHistory = true)
         {
-            if (IncludeHistory)
+            try
             {
-                return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact", "email", email, "profile"));
+                if (IncludeHistory)
+                {
+                    return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact", "email", email, "profile"));
+                }
+                else
+                {
+                    return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact", "email", email, "profile?propertyMode=value_only"));
+                }
             }
-            else
+            catch (HubSpotException exception)
             {
-                return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact", "email", email, "profile?propertyMode=value_only"));
+                if (exception.ReturnedError.StatusCode == HttpStatusCode.NotFound)
+                    return null;
+                throw;
             }
         }
 
@@ -109,13 +128,22 @@ namespace HubSpot.NET.Api.Contact
         /// <returns>The contact entity</returns>
         public ContactHubSpotModel GetByUserToken(string userToken, bool IncludeHistory = true)
         {
-            if(IncludeHistory)
+            try
             {
-                return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact", "utk", userToken, "profile"));
+                if (IncludeHistory)
+                {
+                    return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact", "utk", userToken, "profile"));
+                }
+                else
+                {
+                    return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact", "utk", userToken, "profile?propertyMode=value_only"));
+                }
             }
-            else
+            catch (HubSpotException exception)
             {
-                return _client.Execute<ContactHubSpotModel>(GetRoute<ContactHubSpotModel>("contact", "utk", userToken, "profile?propertyMode=value_only"));
+                if (exception.ReturnedError.StatusCode == HttpStatusCode.NotFound)
+                    return null;
+                throw;
             }
         }
 

--- a/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
+++ b/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
@@ -69,7 +69,7 @@
         /// </summary>
         /// <param name="contactId">ID of the contact</param>
         /// <typeparam name="T">Implementation of ContactHubSpotModel</typeparam>
-        /// <returns>The contact entity</returns>
+        /// <returns>The contact entity or null if the contact does not exist.</returns>
         public ContactHubSpotModel GetById(long contactId, bool IncludeHistory = true)
         {
             try
@@ -98,7 +98,7 @@
         /// </summary>
         /// <param name="email">Email address to search for</param>
         /// <typeparam name="T">Implementation of ContactHubSpotModel</typeparam>
-        /// <returns>The contact entity</returns>
+        /// <returns>The contact entity or null if the contact does not exist.</returns>
         public ContactHubSpotModel GetByEmail(string email, bool IncludeHistory = true)
         {
             try
@@ -125,7 +125,7 @@
         /// </summary>
         /// <param name="userToken">User token to search for from hubspotutk cookie</param>
         /// <typeparam name="T">Implementation of ContactHubSpotModel</typeparam>
-        /// <returns>The contact entity</returns>
+        /// <returns>The contact entity or null if the contact does not exist.</returns>
         public ContactHubSpotModel GetByUserToken(string userToken, bool IncludeHistory = true)
         {
             try

--- a/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
+++ b/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
@@ -1,16 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Flurl;
-using HubSpot.NET.Api.Deal.Dto;
-using HubSpot.NET.Api.Shared;
-using HubSpot.NET.Core;
-using HubSpot.NET.Core.Abstracts;
-using HubSpot.NET.Core.Interfaces;
-using RestSharp;
-
-namespace HubSpot.NET.Api.Deal
+﻿namespace HubSpot.NET.Api.Deal
 {
+    using System;
+    using System.Linq;
+    using System.Net;
+    using Flurl;
+    using HubSpot.NET.Api.Deal.Dto;
+    using HubSpot.NET.Api.Shared;
+    using HubSpot.NET.Core;
+    using HubSpot.NET.Core.Abstracts;
+    using HubSpot.NET.Core.Interfaces;
+    using RestSharp;
+
     public class HubSpotDealApi : ApiRoutable, IHubSpotDealApi
     {
         private readonly IHubSpotClient _client;
@@ -41,9 +41,20 @@ namespace HubSpot.NET.Api.Deal
         /// </summary>
         /// <param name="dealId">ID of the deal</param>
         /// <typeparam name="T">Implementation of DealHubSpotModel</typeparam>
-        /// <returns>The deal entity</returns>
-        public DealHubSpotModel GetById(long dealId) 
-            => _client.Execute<DealHubSpotModel>(GetRoute<DealHubSpotModel>(dealId.ToString()));
+        /// <returns>The deal entity or null if the deal does not exist.</returns>
+        public DealHubSpotModel GetById(long dealId)
+        {
+            try
+            {
+                return _client.Execute<DealHubSpotModel>(GetRoute<DealHubSpotModel>(dealId.ToString()));
+            }
+            catch (HubSpotException exception)
+            {
+                if (exception.ReturnedError.StatusCode == HttpStatusCode.NotFound)
+                    return null;
+                throw;
+            }
+        }
 
         /// <summary>
         /// Updates a given deal

--- a/HubSpot.NET/Api/EmailEvents/HubSpotEmailEventsApi.cs
+++ b/HubSpot.NET/Api/EmailEvents/HubSpotEmailEventsApi.cs
@@ -1,16 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Flurl;
-using HubSpot.NET.Api.EmailEvents.Dto;
-using HubSpot.NET.Core;
-using HubSpot.NET.Core.Interfaces;
-using RestSharp;
-
-namespace HubSpot.NET.Api.EmailEvents
+﻿namespace HubSpot.NET.Api.EmailEvents
 {
+	using System.Net;
+	using Flurl;
+    using HubSpot.NET.Api.EmailEvents.Dto;
+	using HubSpot.NET.Core;
+	using HubSpot.NET.Core.Interfaces;
+    using RestSharp;
+
     public class HubSpotEmailEventsApi : IHubSpotEmailEventsApi
     {
         private readonly IHubSpotClient _client;
@@ -26,13 +22,22 @@ namespace HubSpot.NET.Api.EmailEvents
         /// <param name="campaignId">The campaign ID to query.</param>
         /// <param name="appId">The app ID to query.</param>
         /// <typeparam name="T">Implementation of EmailCampaignDataHubSpotModel</typeparam>
-        /// <returns>The xcampaign data entity</returns>
+        /// <returns>The campaign data entity or null if the compaign does not exist.</returns>
         public T GetCampaignDataById<T>(long campaignId, long appId) where T : EmailCampaignDataHubSpotModel, new()
         {
             var path = $"{(new T()).RouteBasePath}/{campaignId}"
                 .SetQueryParam("appId", appId);
-            var data = _client.Execute<T>(path, Method.GET);
-            return data;
+            try
+            {
+                var data = _client.Execute<T>(path, Method.GET);
+                return data;
+            }
+            catch (HubSpotException exception)
+            {
+                if (exception.ReturnedError.StatusCode == HttpStatusCode.NotFound)
+                    return null;
+                throw;
+            }
         }
 
         /// <summary>

--- a/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
+++ b/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
@@ -1,12 +1,14 @@
-﻿using System;
-using Flurl;
-using HubSpot.NET.Api.Engagement.Dto;
-using HubSpot.NET.Core.Abstracts;
-using HubSpot.NET.Core.Interfaces;
-using RestSharp;
-
-namespace HubSpot.NET.Api.Engagement
+﻿namespace HubSpot.NET.Api.Engagement
 {
+    using System;
+	using System.Net;
+	using Flurl;
+    using HubSpot.NET.Api.Engagement.Dto;
+	using HubSpot.NET.Core;
+	using HubSpot.NET.Core.Abstracts;
+    using HubSpot.NET.Core.Interfaces;
+    using RestSharp;
+
     public class HubSpotEngagementApi : ApiRoutable, IHubSpotEngagementApi
     {
         private readonly IHubSpotClient _client;
@@ -42,9 +44,20 @@ namespace HubSpot.NET.Api.Engagement
         /// Gets a given engagement (by ID)
         /// </summary>
         /// <param name="engagementId">The ID of the engagement</param>
-        /// <returns>The engagement</returns>
-        public EngagementHubSpotModel GetById(long engagementId) 
-            => _client.Execute<EngagementHubSpotModel>(GetRoute<EngagementHubSpotModel>(engagementId.ToString()));
+        /// <returns>The engagement or null if the engagement does not exist.</returns>
+        public EngagementHubSpotModel GetById(long engagementId)
+        {
+            try
+            {
+                return _client.Execute<EngagementHubSpotModel>(GetRoute<EngagementHubSpotModel>(engagementId.ToString()));
+            }
+            catch (HubSpotException exception)
+            {
+                if (exception.ReturnedError.StatusCode == HttpStatusCode.NotFound)
+                    return null;
+                throw;
+            }
+        }
 
         /// <summary>
         /// Retrieves a paginated list of engagements

--- a/HubSpot.NET/Api/Files/HubSpotCosFileApi.cs
+++ b/HubSpot.NET/Api/Files/HubSpotCosFileApi.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
-using HubSpot.NET.Api.Files.Dto;
-using HubSpot.NET.Core.Abstracts;
-using HubSpot.NET.Core.Interfaces;
-using RestSharp;
-
-namespace HubSpot.NET.Api.Files
+﻿namespace HubSpot.NET.Api.Files
 {
+    using System.Collections.Generic;
+    using HubSpot.NET.Api.Files.Dto;
+    using HubSpot.NET.Core.Abstracts;
+    using HubSpot.NET.Core.Interfaces;
+    using RestSharp;
+
     public class HubSpotCosFileApi : ApiRoutable, IHubSpotCosFileApi
     {
         private readonly IHubSpotClient _client;

--- a/HubSpot.NET/Api/Owner/HubSpotOwnerApi.cs
+++ b/HubSpot.NET/Api/Owner/HubSpotOwnerApi.cs
@@ -1,9 +1,9 @@
-using HubSpot.NET.Api.Owner.Dto;
-using HubSpot.NET.Core.Abstracts;
-using HubSpot.NET.Core.Interfaces;
-
 namespace HubSpot.NET.Api.Owner
 {
+    using HubSpot.NET.Api.Owner.Dto;
+    using HubSpot.NET.Core.Abstracts;
+    using HubSpot.NET.Core.Interfaces;
+
     public class HubSpotOwnerApi : ApiRoutable, IHubSpotOwnerApi
     {
         private readonly IHubSpotClient _client;

--- a/HubSpot.NET/Api/Properties/HubSpotCompaniesPropertiesApi.cs
+++ b/HubSpot.NET/Api/Properties/HubSpotCompaniesPropertiesApi.cs
@@ -1,10 +1,10 @@
-using HubSpot.NET.Api.Properties.Dto;
-using HubSpot.NET.Core.Abstracts;
-using HubSpot.NET.Core.Interfaces;
-using RestSharp;
-
 namespace HubSpot.NET.Api.Properties
 {
+    using HubSpot.NET.Api.Properties.Dto;
+    using HubSpot.NET.Core.Abstracts;
+    using HubSpot.NET.Core.Interfaces;
+    using RestSharp;
+
     public class HubSpotCompaniesPropertiesApi : ApiRoutable, IHubSpotCompanyPropertiesApi
     {
         private readonly IHubSpotClient _client;

--- a/HubSpot.NET/Api/Timeline/HubSpotTimelineApi.cs
+++ b/HubSpot.NET/Api/Timeline/HubSpotTimelineApi.cs
@@ -1,11 +1,13 @@
 ﻿namespace HubSpot.NET.Api.Timeline
 {
     using HubSpot.NET.Api.Timeline.Dto;
-    using HubSpot.NET.Core.Abstracts;
+	using HubSpot.NET.Core;
+	using HubSpot.NET.Core.Abstracts;
     using HubSpot.NET.Core.Interfaces;
     using System.Collections.Generic;
+	using System.Net;
 
-    public class HubSpotTimelineApi : ApiRoutable, IHubSpotTimelineApi
+	public class HubSpotTimelineApi : ApiRoutable, IHubSpotTimelineApi
     {
         private readonly IHubSpotClient _client;
 
@@ -34,8 +36,18 @@
         
 
         public TimelineEventHubSpotModel GetEventById(long entityID)
-        =>_client.Execute<TimelineEventHubSpotModel>(GetRoute<TimelineEventHubSpotModel>(entityID.ToString()));
-        
+        {
+            try
+            {
+                return _client.Execute<TimelineEventHubSpotModel>(GetRoute<TimelineEventHubSpotModel>(entityID.ToString()));
+            }
+            catch (HubSpotException exception)
+            {
+                if (exception.ReturnedError.StatusCode == HttpStatusCode.NotFound)
+                    return null;
+                throw;
+            }
+        }
 
         public IEnumerable<TimelineEventTypeHubSpotModel> GetAllEventTypes()
         => _client.Execute<List<TimelineEventTypeHubSpotModel>>(GetRoute<TimelineEventTypeHubSpotModel>());


### PR DESCRIPTION
## Description
Added better 404 (not found) handling if calling a GetByX method. Returning an exception is messy handling and far from standard pattern handling, in addition to that executing a search for a single well known query is an overkill solution.

## Purpose
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests to prove that what I have fixed or added does indeed work
- [x ] I have added documentation as necessary
