### PR TITLE
Ability to query company property groups

### DIFF
--- a/HubSpot.NET/Api/Properties/Dto/CompanyPropertyGroupHubSpotModel.cs
+++ b/HubSpot.NET/Api/Properties/Dto/CompanyPropertyGroupHubSpotModel.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.Serialization;
+using HubSpot.NET.Core.Interfaces;
+
+namespace HubSpot.NET.Api.Properties.Dto
+{
+    public class CompanyPropertyGroupHubSpotModel : IHubSpotModel
+    {
+        [DataMember(Name = "name")]
+        public string Name { get; set; }
+        
+        [DataMember(Name = "fulcrumPortalId")]
+        public int FulcrumPortalId { get; set; }
+        
+        [DataMember(Name = "displayName")]
+        public string DisplayName { get; set; }
+        
+        [DataMember(Name = "displayOrder")]
+        public int DisplayOrder { get; set; }
+        
+        [DataMember(Name = "hubspotDefined")]
+        public bool HubSpotDefined { get; set; }
+        
+        public bool IsNameValue => false;
+    }
+}

--- a/HubSpot.NET/Api/Properties/HubSpotCompanyPropertyGroupsApi.cs
+++ b/HubSpot.NET/Api/Properties/HubSpotCompanyPropertyGroupsApi.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using HubSpot.NET.Api.Properties.Dto;
+using HubSpot.NET.Core.Abstracts;
+using HubSpot.NET.Core.Interfaces;
+using RestSharp;
+
+namespace HubSpot.NET.Api.Properties
+{
+    public class HubSpotCompanyPropertyGroupsApi : ApiRoutable, IHubSpotCompanyPropertyGroupsApi
+    {
+        private readonly IHubSpotClient _client;
+        public override string MidRoute => "/properties/v1";
+
+        public HubSpotCompanyPropertyGroupsApi(IHubSpotClient client)
+        {
+            _client = client;
+            AddRoute<CompanyPropertyGroupHubSpotModel>("/companies/groups");
+        }
+
+        public IEnumerable<CompanyPropertyGroupHubSpotModel> GetAll()
+            => _client.Execute<List<CompanyPropertyGroupHubSpotModel>>(GetRoute<CompanyPropertyGroupHubSpotModel>());
+
+        public CompanyPropertyGroupHubSpotModel Create(CompanyPropertyGroupHubSpotModel property)
+            => _client.Execute<CompanyPropertyGroupHubSpotModel, CompanyPropertyGroupHubSpotModel>(GetRoute<CompanyPropertyGroupHubSpotModel>(), property, Method.POST);
+    }
+}

--- a/HubSpot.NET/Core/HubSpotApi.cs
+++ b/HubSpot.NET/Core/HubSpotApi.cs
@@ -28,6 +28,7 @@
         public IHubSpotCosFileApi File { get; private set; }
         public IHubSpotOwnerApi Owner { get; private set; }
         public IHubSpotCompanyPropertiesApi CompanyProperties { get; private set; }
+        public IHubSpotCompanyPropertyGroupsApi CompanyPropertyGroups { get; private set; }
         public IHubSpotEmailEventsApi EmailEvents { get; private set; }
         public IHubSpotEmailSubscriptionsApi EmailSubscriptions { get; private set; }
         public IHubSpotTimelineApi Timelines { get; private set; }
@@ -70,6 +71,7 @@
             File = new HubSpotCosFileApi(client);
             Owner = new HubSpotOwnerApi(client);
             CompanyProperties = new HubSpotCompaniesPropertiesApi(client);
+            CompanyPropertyGroups = new HubSpotCompanyPropertyGroupsApi(client);
             EmailSubscriptions = new HubSpotEmailSubscriptionsApi(client);
             Timelines = new HubSpotTimelineApi(client);
 

--- a/HubSpot.NET/Core/HubSpotBaseClient.cs
+++ b/HubSpot.NET/Core/HubSpotBaseClient.cs
@@ -111,7 +111,7 @@ namespace HubSpot.NET.Core
         {
             RestRequest request = ConfigureRequestAuthentication(path, method);
            
-            if(entity != default)
+            if(!entity.Equals(default(K)))
                 request.AddJsonBody(entity);
             
 
@@ -136,7 +136,7 @@ namespace HubSpot.NET.Core
 
             RestRequest request = ConfigureRequestAuthentication(path, method);
 
-            if (entity != default)
+            if (!entity.Equals(default(T)))
                 request.AddJsonBody(entity);
 
             IRestResponse response = _client.Execute(request);

--- a/HubSpot.NET/Core/Interfaces/IHubSpotApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotApi.cs
@@ -12,6 +12,7 @@ namespace HubSpot.NET.Core.Interfaces
         IHubSpotCosFileApi File { get; }
         IHubSpotOwnerApi Owner { get; }
         IHubSpotCompanyPropertiesApi CompanyProperties { get; }
+        IHubSpotCompanyPropertyGroupsApi CompanyPropertyGroups { get; }
         IHubSpotEmailSubscriptionsApi EmailSubscriptions { get; }
     }
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCompanyPropertyGroupsApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCompanyPropertyGroupsApi.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using HubSpot.NET.Api.Properties.Dto;
+
+namespace HubSpot.NET.Core.Interfaces
+{
+    public interface IHubSpotCompanyPropertyGroupsApi
+    {
+        IEnumerable<CompanyPropertyGroupHubSpotModel> GetAll();
+        CompanyPropertyGroupHubSpotModel Create(CompanyPropertyGroupHubSpotModel property);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Tell us a little bit about the changes you have made and why you think they are important -->
While using this library in a project we found the need to query the Company Property Groups in HubSpot, but the functionality wasn't there. I've added this very basic functionality following the same logic that the rest of them use. I have tested this manually with HubSpot. With regards to testing, not sure how is best to do this as there doesn't appear to be any tests for testing the existing interfaces, so happy to follow guidance on that.

I also had to edit the base client as it didn't appear to build due to the `entity != default` line, so I've put a fix for that. Again happy to follow guidance.

## Purpose
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests to prove that what I have fixed or added does indeed work
- [x] I have added documentation as necessary
